### PR TITLE
Fixing the tls_client to have full control of the tls file locations.

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -1,7 +1,25 @@
-includes: ['layer:basic', 'interface:tls-certificates'] 
 repo: https://github.com/juju-solutions/layer-tls-client.git
+includes: 
+  - 'layer:basic'
+  - 'interface:tls-certificates'
 defines:
-  certificates-directory:
-    description: The path to store the certificates.
+  ca_certificate_path:
     type: string
-    default: ""
+    default: ''
+    description: The absolute path to save the Certificate Authority (CA) file. 
+  server_certificate_path:
+    type: string
+    default: ''
+    description: The absolute path to save the server certificate file.
+  server_key_path:
+    type: string
+    default: ''
+    description: The absolute path to save the server key file.
+  client_certificate_path:
+    type: string
+    default: ''
+    description: The absolute path to save the client certificiate file.
+  client_key_path:
+    type: string
+    default: ''
+    description: The absolute path to save the client key file.

--- a/reactive/tls_client.py
+++ b/reactive/tls_client.py
@@ -1,88 +1,68 @@
 import os
-import socket
 
 from subprocess import check_call
 
 from charms import layer
+from charms.reactive import when
+from charms.reactive.helpers import data_changed
 
-from charms.reactive import when, when_not, set_state
 from charmhelpers.core import hookenv
+from charmhelpers.core.hookenv import log
 
 
-@when_not('tls-client.certificates.directory')
-def get_directory():
-    '''Get the layer option of where to put the certificates.'''
-    layer_options = layer.options('tls-client')
-    if layer_options.get('certificates-directory'):
-        set_state('tls-client.certificates.directory')
-    else:
-        hookenv.status_set('blocked',
-                           'Missing certificates_directory layer option.')
-
-
-@when('certificates.ca.available', 'tls-client.certificates.directory')
+@when('certificates.ca.available')
 def store_ca(tls):
     '''Read the certificate authority from the relation object and install
     the ca on this system.'''
     # Get the CA from the relationship object.
     certificate_authority = tls.get_ca()
     if certificate_authority:
-        # Update /etc/ssl/certs and generate ca-certificates.crt
-        install_ca(certificate_authority)
-
         layer_options = layer.options('tls-client')
-        # Get the certificate directory from the layer options.
-        directory = layer_options.get('certificates-directory')
-        if not os.path.isdir(directory):
-            os.makedirs(directory)
-        destination = os.path.join(directory, 'ca.crt')
-        hookenv.log('Writing the CA to {0}'.format(destination))
-        with open(destination, 'w') as fp:
-            fp.write(certificate_authority)
+        if data_changed('certificate_authority', certificate_authority):
+            ca_path = layer_options.get('ca_certificate_path')
+            if ca_path:
+                log('Writing CA certificate to {0}'.format(ca_path))
+                _write_file(ca_path, certificate_authority)
+            # Update /etc/ssl/certs and generate ca-certificates.crt
+            install_ca(certificate_authority)
 
 
 @when('certificates.server.cert.available')
-@when('tls-client.certificates.directory')
 def store_server(tls):
     '''Read the server certificate and server key from the relation object
     and save them to the certificate directory..'''
     server_cert, server_key = tls.get_server_cert()
     if server_cert and server_key:
         layer_options = layer.options('tls-client')
-        # Get the certificate directory from the layer options.
-        directory = layer_options.get('certificates-directory')
-        if not os.path.isdir(directory):
-            os.makedirs(directory)
-        cert_file = os.path.join(directory, 'server.crt')
-        hookenv.log('Writing server certificate to {0}'.format(cert_file))
-        with open(cert_file, 'w') as stream:
-            stream.write(server_cert)
-        key_file = os.path.join(directory, 'server.key')
-        hookenv.log('Writing server key to {0}'.format(key_file))
-        with open(key_file, 'w') as stream:
-            stream.write(server_key)
+        if data_changed('server_certificate', server_cert):
+            cert_path = layer_options.get('server_certificate_path')
+            if cert_path:
+                log('Writing server certificate to {0}'.format(cert_path))
+                _write_file(cert_path, server_cert)
+        if data_changed('server_key', server_key):
+            key_path = layer_options.get('server_key_path')
+            if key_path:
+                log('Writing server key to {0}'.format(key_path))
+                _write_file(key_path, server_key)
 
 
 @when('certificates.client.cert.available')
-@when('tls-client.certificates.directory')
 def store_client(tls):
     '''Read the client certificate and client key from the relation object
     and copy them to the certificate directory.'''
     client_cert, client_key = tls.get_client_cert()
     if client_cert and client_key:
         layer_options = layer.options('tls-client')
-        # Get the certificate directory from the layer options.
-        directory = layer_options.get('certificates-directory')
-        if not os.path.isdir(directory):
-            os.makedirs(directory)
-        cert_file = os.path.join(directory, 'client.crt')
-        hookenv.log('Writing client certificate to {0}'.format(cert_file))
-        with open(cert_file, 'w') as stream:
-            stream.write(client_cert)
-        key_file = os.path.join(directory, 'client.key')
-        hookenv.log('Writing client key to {0}'.format(key_file))
-        with open(key_file, 'w') as stream:
-            stream.write(client_key)
+        if data_changed('client_certificate', client_cert):
+            cert_path = layer_options.get('client_certificate_path')
+            if cert_path:
+                log('Writing client certificate to {0}'.format(cert_path))
+                _write_file(cert_path, client_cert)
+        if data_changed('client_key', client_key):
+            key_path = layer_options.get('client_key_path')
+            if key_path:
+                log('Writing client key to {0}'.format(key_path))
+                _write_file(key_path, client_key)
 
 
 def install_ca(certificate_authority):
@@ -90,12 +70,26 @@ def install_ca(certificate_authority):
     update-ca-certificates command.'''
     if certificate_authority:
         name = hookenv.service_name()
-        ca_file = '/usr/local/share/ca-certificates/{0}.crt'.format(name)
-        hookenv.log('Writing CA to {0}'.format(ca_file))
-        # Write the contents of certificate authority to the file.
-        with open(ca_file, 'w') as fp:
-            fp.write(certificate_authority)
-        # Update the trusted CAs on this system.
+        # Create a path to install CAs on Debian systems.
+        ca_path = '/usr/local/share/ca-certificates/{0}.crt'.format(name)
+        log('Writing CA certificate to {0}'.format(ca_path))
+        _write_file(ca_path, certificate_authority)
+        # Update the trusted CAs on this system (a time expensive operation).
         check_call(['update-ca-certificates'])
-        message = 'Generated ca-certificates.crt for {0}'.format(name)
-        hookenv.log(message)
+        log('Generated ca-certificates.crt for {0}'.format(name))
+
+
+def _ensure_directory(path):
+    '''Ensure the parent directory exists creating directories if necessary.'''
+    directory = os.path.dirname(path)
+    if not os.path.isdir(directory):
+        os.makedirs(directory)
+    os.chmod(directory, 0o770)
+
+
+def _write_file(path, content):
+    '''Write the path to a file.'''
+    _ensure_directory(path)
+    with open(path, 'w') as stream:
+        stream.write(content)
+    os.chmod(path, 0o770)


### PR DESCRIPTION
- Added file locations for all the certificates.
- Added caching of the previous values so we don't write certs/keys all the time.
- Changed the code to use that
- Changed the permission on the cert_dir and cert files that are written to avoid insecure reads from random users.
