### PR TITLE
Fix lint errors

### DIFF
--- a/lib/charms/layer/tls_client.py
+++ b/lib/charms/layer/tls_client.py
@@ -18,10 +18,12 @@ from charmhelpers.core.hookenv import log
 
 from charms.reactive import remove_state
 
-# Reset the certificate written flag so notification will work on the next write
-# cert_type must be 'server', 'client', or 'ca' to indicate type of certificate
+
+# Reset the certificate written flag so notification will work on the next
+# write cert_type must be 'server', 'client', or 'ca' to indicate type of
+# certificate
 def reset_certificate_write_flag(cert_type):
-    if not cert_type == 'server' and not cert_type == 'client' and not cert_type == 'ca':
+    if cert_type not in ['server', 'client', 'ca']:
         log('Unknown certificate type!')
     else:
         remove_state('tls_client.{0}.certificate.written'.format(cert_type))


### PR DESCRIPTION
Fixes the following errors:
DEBUG:runner:lib/charms/layer/tls_client.py:21:80: E501 line too long (80 > 79 characters)
DEBUG:runner:lib/charms/layer/tls_client.py:23:1: E302 expected 2 blank lines, found 1
DEBUG:runner:lib/charms/layer/tls_client.py:24:80: E501 line too long (89 > 79 characters)
DEBUG:runner:Makefile:11: recipe for target 'lint' failed
DEBUG:runner:make: *** [lint] Error 1
