### PR TITLE
modified chmod permissions on new files (certs) from 770 to 440

### DIFF
--- a/reactive/tls_client.py
+++ b/reactive/tls_client.py
@@ -118,4 +118,4 @@ def _write_file(path, content):
     _ensure_directory(path)
     with open(path, 'w') as stream:
         stream.write(content)
-    os.chmod(path, 0o770)
+    os.chmod(path, 0o440)


### PR DESCRIPTION
Modified layer-tls-client to fix [https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/336](https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/336). 

The permissions 0770 for certs in /root/cdk/ were too open because of the function in the end of the file: 

[https://github.com/juju-solutions/layer-tls-client/blob/master/reactive/tls_client.py](https://github.com/juju-solutions/layer-tls-client/blob/master/reactive/tls_client.py)

```
def _write_file(path, content):
    '''Write the path to a file.'''
    _ensure_directory(path)
    with open(path, 'w') as stream:
        stream.write(content)
    os.chmod(path, 0o770)
```

So this has been changed to: 

```
def _write_file(path, content):
    '''Write the path to a file.'''
    _ensure_directory(path)
    with open(path, 'w') as stream:
        stream.write(content)
    os.chmod(path, 0o440)
```

These certs are placed in /root/cdk on the etcd node, the kubernetes-master,  kubernetes-worker and kubeapi-load-balancer so the permissions were wrong for certs on all four node types.  

We can see they are deployed by inspecting the logs for juju on each node, for example: 

> 2018-01-10 17:59:45 INFO juju-log certificates:4: Invoking reactive handler: hooks/relations/tls-certificates/requires.py:22:changed
> 2018-01-10 17:59:48 INFO juju-log certificates:4: Invoking reactive handler: reactive/kubernetes_master.py:540:send_data
> 2018-01-10 17:59:53 INFO juju-log certificates:4: Invoking reactive handler: reactive/kubernetes_master.py:450:etcd_data_change
> 2018-01-10 17:59:55 INFO juju-log certificates:4: Invoking reactive handler: reactive/kubernetes_master.py:382:set_app_version
> 2018-01-10 17:59:56 INFO juju-log certificates:4: Invoking reactive handler: reactive/kubernetes_master.py:482:create_service_configs
> 2018-01-10 17:59:58 INFO juju-log certificates:4: Invoking reactive handler: reactive/tls_client.py:36:store_server
> 2018-01-10 17:59:59 INFO juju-log certificates:4: Writing server certificate to /root/cdk/server.crt
> 2018-01-10 18:00:00 INFO juju-log certificates:4: Writing server key to /root/cdk/server.key
> 2018-01-10 18:00:00 INFO juju-log certificates:4: Invoking reactive handler: reactive/tls_client.py:60:store_client
> 2018-01-10 18:00:01 INFO juju-log certificates:4: Writing client certificate to /root/cdk/client.crt
> 2018-01-10 18:00:01 INFO juju-log certificates:4: Writing client key to /root/cdk/client.key
> 2018-01-10 18:00:02 INFO juju-log certificates:4: Invoking reactive handler: reactive/tls_client.py:15:store_ca
> 2018-01-10 18:00:02 INFO juju-log certificates:4: Writing CA certificate to /root/cdk/ca.crt
> 2018-01-10 18:00:03 INFO juju-log certificates:4: Writing CA certificate to /usr/local/share/ca-certificates/kubernetes-master.crt
> 

Anyway, the simple permission change fixes this issue. Also note, there is a directory creation function with the same permission issue: 

```
def _ensure_directory(path):
    '''Ensure the parent directory exists creating directories if necessary.'''
    directory = os.path.dirname(path)
    if not os.path.isdir(directory):
        os.makedirs(directory)
    os.chmod(directory, 0o770)
```

My guess is that this can also be amended but I need to test that change too. Thoughts? 

Also I'm new to Juju, if we update this interface, I assume there is a CD/CI pipeline which will populate the change into the other charms (etcd, kubernetes-master, kubernetes-worker, kubeapi-load-balancer). Is this correct? 

Cheers,

- Calvin 