### PR TITLE
Add debug script to grab TLS certs (not keys!)

### DIFF
--- a/debug-scripts/tls-certs
+++ b/debug-scripts/tls-certs
@@ -1,0 +1,21 @@
+#!/usr/local/sbin/charm-env python3
+
+import os
+import shutil
+import traceback
+import debug_script
+from charms import layer
+
+options = layer.options.get('tls-client')
+
+def copy_cert(source_key, name):
+    try:
+        source = options[source_key]
+        dest = os.path.join(debug_script.dir, name)
+        shutil.copy(source, dest)
+    except Exception:
+        traceback.print_exc()
+
+copy_cert('client_certificate_path', 'client.crt')
+copy_cert('server_certificate_path', 'server.crt')
+copy_cert('ca_certificate_path', 'ca.crt')

--- a/layer.yaml
+++ b/layer.yaml
@@ -1,6 +1,7 @@
 repo: https://github.com/juju-solutions/layer-tls-client.git
 includes: 
   - 'layer:basic'
+  - 'layer:debug'
   - 'interface:tls-certificates'
 defines:
   ca_certificate_path:


### PR DESCRIPTION
Additional debug info to help with https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/610. I would like to see what SANs are being used in the certs.