### PR TITLE
Refactor handling of certificate requests

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -1,5 +1,5 @@
 repo: https://github.com/juju-solutions/layer-tls-client.git
-includes: 
+includes:
   - 'layer:basic'
   - 'layer:debug'
   - 'interface:tls-certificates'
@@ -7,20 +7,32 @@ defines:
   ca_certificate_path:
     type: string
     default: ''
-    description: The absolute path to save the Certificate Authority (CA) file. 
+    description: The absolute path to save the Certificate Authority (CA) file.
   server_certificate_path:
     type: string
     default: ''
-    description: The absolute path to save the server certificate file.
+    description: |
+      The absolute path to save the server certificate file.
+      This is deprecated in favor of calling `layer.tls_client.request_server_cert`
+      and passing the paths in to that.
   server_key_path:
     type: string
     default: ''
-    description: The absolute path to save the server key file.
+    description: |
+      The absolute path to save the server key file.
+      This is deprecated in favor of calling `layer.tls_client.request_server_cert`
+      and passing the paths in to that.
   client_certificate_path:
     type: string
     default: ''
-    description: The absolute path to save the client certificiate file.
+    description: |
+      The absolute path to save the client certificiate file.
+      This is deprecated in favor of calling `layer.tls_client.request_client_cert`
+      and passing the paths in to that.
   client_key_path:
     type: string
     default: ''
-    description: The absolute path to save the client key file.
+    description: |
+      The absolute path to save the client key file.
+      This is deprecated in favor of calling `layer.tls_client.request_client_cert`
+      and passing the paths in to that.

--- a/lib/charms/layer/tls_client.py
+++ b/lib/charms/layer/tls_client.py
@@ -15,15 +15,47 @@
 # limitations under the License.
 
 from charmhelpers.core.hookenv import log
+from charmhelpers.core import unitdata
 
 from charms.reactive import remove_state
+from charms.reactive import endpoint_from_flag
 
 
-# Reset the certificate written flag so notification will work on the next
-# write cert_type must be 'server', 'client', or 'ca' to indicate type of
-# certificate
 def reset_certificate_write_flag(cert_type):
+    """
+    Reset the certificate written flag so notification will work on the next
+    write cert_type must be 'server', 'client', or 'ca' to indicate type of
+    certificate
+    """
     if cert_type not in ['server', 'client', 'ca']:
         log('Unknown certificate type!')
     else:
         remove_state('tls_client.{0}.certificate.written'.format(cert_type))
+
+
+def request_server_cert(common_name, sans=None, crt_path=None, key_path=None):
+    tls = endpoint_from_flag('certificates.available')
+    tls.request_server_cert(common_name, sans)
+    if not crt_path and not key_path:
+        return
+    kv = unitdata.kv()
+    cert_paths = kv.get('layer.tls-client.cert-paths', {})
+    cert_paths.setdefault('server', {})[common_name] = {
+        'crt': str(crt_path),
+        'key': str(key_path),
+    }
+    kv.set('layer.tls-client.cert-paths', cert_paths)
+
+
+def request_client_cert(common_name, sans=None, crt_path=None, key_path=None):
+    tls = endpoint_from_flag('certificates.available')
+    tls.request_client_cert(common_name, sans)
+    if not crt_path and not key_path:
+        return
+    kv = unitdata.kv()
+    cert_paths = kv.get('layer.tls-client.cert-paths', {})
+    cert_paths.setdefault('client', {})[common_name] = {
+        'crt': str(crt_path),
+        'key': str(key_path),
+    }
+    kv.set('layer.tls-client.cert-paths', cert_paths)


### PR DESCRIPTION
Deprecate layer options and the global shared client certificate in favor of explicitly requested server and client certificates.

Depends on https://github.com/juju-solutions/layer-easyrsa/pull/16
