### PR TITLE
Ensure parent path for certs exist

### DIFF
--- a/reactive/tls_client.py
+++ b/reactive/tls_client.py
@@ -145,9 +145,11 @@ def update_certs():
             if cert:
                 if chain:
                     cert = cert + '\n' + chain
+                _ensure_directory(paths['crt'])
                 Path(paths['crt']).write_text(cert)
 
             if key:
+                _ensure_directory(paths['key'])
                 Path(paths['key']).write_text(key)
 
             any_changed = True


### PR DESCRIPTION
It seems the parent path for certs is usually but not always created before the certs are written. This adds a check to ensure the parent paths always exist before writing the certs or keys.

Fixes [lp:1899650](https://bugs.launchpad.net/charm-kubeapi-load-balancer/+bug/1899650)